### PR TITLE
add test for boost::lexical_cast

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,7 @@ add_executable(
   src/ryutest.cpp
   src/doubleconvtest.cpp
   src/fmttest.cpp
+  src/boosttest.cpp
   src/fpconvtest.cpp
   src/gaytest.cpp
   src/grisu2btest.cpp

--- a/src/boosttest.cpp
+++ b/src/boosttest.cpp
@@ -1,0 +1,10 @@
+#include "test.h"
+#include <boost/lexical_cast.hpp>
+#include <string>
+
+void dtoa_boost(double value, char* buffer) {
+  std::string str = boost::lexical_cast<std::string>(value);
+  strcpy(buffer, str.c_str()); 
+}
+
+REGISTER_TEST(boost);


### PR DESCRIPTION
AFAIK, only the `boost/lexical_cast.hpp` header is needed. Maybe we could check in the CMakeLists.txt if this is available and disable the test if it is not available.