### PR TITLE
Detect OS and CPU name on x86-64 linux

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,15 +59,11 @@ elseif(LINUX)
     COMMAND lscpu
     OUTPUT_VARIABLE CPU_NAME
   )
-  string(REGEX MATCH "Model name: [^\n]*\n" CPU_NAME "${CPU_NAME}")
-  string(REPLACE "Model name: " "" CPU_NAME "${CPU_NAME}")
-  string(REGEX REPLACE "[^ ]+-Core Processor" "" CPU_NAME "${CPU_NAME}")
-  string(REPLACE "(R)" "" CPU_NAME "${CPU_NAME}")
-  string(REPLACE "(TM)" "" CPU_NAME "${CPU_NAME}")
-  string(REPLACE "AMD" "" CPU_NAME "${CPU_NAME}")
-  string(REPLACE "Intel" "" CPU_NAME "${CPU_NAME}")
-  string(REPLACE "CPU" "" CPU_NAME "${CPU_NAME}")
-  string(REPLACE "@ " "@" CPU_NAME "${CPU_NAME}")
+  string(REGEX MATCH "Model name: ([^\n]*)\n" CPU_NAME "${CPU_NAME}")
+  string(REGEX REPLACE
+    "AMD|Intel|CPU|\\(R\\)|\\(TM\\)|@|[^ ]+-Core Processor" ""
+    CPU_NAME "${CMAKE_MATCH_1}"
+  )
 else ()
   set(CPU_NAME "unknown")
 endif ()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,13 +53,30 @@ if (APPLE)
   execute_process(
     COMMAND sysctl -n machdep.cpu.brand_string
     OUTPUT_VARIABLE CPU_NAME
-    OUTPUT_STRIP_TRAILING_WHITESPACE
   )
-  string(REPLACE " " "-" CPU_NAME "${CPU_NAME}")
-  string(TOLOWER "${CPU_NAME}" CPU_NAME)
+elseif(LINUX)
+  execute_process(
+    COMMAND lscpu
+    OUTPUT_VARIABLE CPU_NAME
+  )
+  string(REGEX MATCH "Model name: [^\n]*\n" CPU_NAME "${CPU_NAME}")
+  string(REPLACE "Model name: " "" CPU_NAME "${CPU_NAME}")
+  string(REGEX REPLACE "[^ ]+-Core Processor" "" CPU_NAME "${CPU_NAME}")
+  string(REPLACE "(R)" "" CPU_NAME "${CPU_NAME}")
+  string(REPLACE "(TM)" "" CPU_NAME "${CPU_NAME}")
+  string(REPLACE "AMD" "" CPU_NAME "${CPU_NAME}")
+  string(REPLACE "Intel" "" CPU_NAME "${CPU_NAME}")
+  string(REPLACE "CPU" "" CPU_NAME "${CPU_NAME}")
+  string(REPLACE "@ " "@" CPU_NAME "${CPU_NAME}")
 else ()
   set(CPU_NAME "unknown")
 endif ()
+
+string(STRIP "${CPU_NAME}" CPU_NAME)
+string(REPLACE "  " " " CPU_NAME "${CPU_NAME}")
+string(REPLACE " " "-" CPU_NAME "${CPU_NAME}")
+string(TOLOWER "${CPU_NAME}" CPU_NAME)
+message("CPU_NAME: ${CPU_NAME}")
 target_compile_definitions(dtoa-benchmark PRIVATE MACHINE="${CPU_NAME}")
 
 add_custom_target(

--- a/src/resultfilename.h
+++ b/src/resultfilename.h
@@ -23,6 +23,10 @@
 #  elif TARGET_OS_MAC
 #    define OS "mac64"
 #  endif
+#elif defined(__linux__)
+#  if defined(__x86_64__) || defined(_M_X64)
+#    define OS "linux64"
+#  endif
 #endif
 
 #ifndef OS


### PR DESCRIPTION
There doesn't seem to be a nice way to get the CPU on linux like on mac OS, so I'm parsing the output of lscpu and stripping some redundant information, which should give something meaningful for most CPUs

For the OS I'm just adding a simple check for the linux and x64 preprocessor flags since I don't have a 32-bit machine to test it on