### PR TITLE
Sync changes from Asteria

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ ostringstream | [`std::ostringstream`](https://en.cppreference.com/w/cpp/io/basi
 [schubfach](https://github.com/vitaut/schubfach) | Schubfach implementation in C++
 sprintf       | [`sprintf`](https://en.cppreference.com/w/c/io/fprintf.html) from the C standard library with `"%.17g"` format.
 [zmij](https://github.com/vitaut/zmij) | `zmij::to_string`
+[asteria](https://github.com/lhmouse/asteria) | `rocket::ascii_numput::put_DD` (decimal double)
 
 Notes:
 

--- a/src/asteria/LICENSE
+++ b/src/asteria/LICENSE
@@ -1,0 +1,29 @@
+BSD 3-Clause License
+
+Copyright (C) 2018-2025, LH_Mouse <lh_mouse@126.com>
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+* Neither the name of the copyright holder nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.


### PR DESCRIPTION
1. Add a link in _Implementations_ in README.md.
2. Add a copy of LICENSE from Asteria, as source files don't convey copies of license text.
3. Sync changes from upstream:
   1. Use unsigned integers in pointer arithmetic to avoid potential sign-extension on 64-bit systems.
   2. Fix an issue that a custom decimal point was not used in plain forms that start with zero, such as `0.0123`.
   3. Simplify `do_write_mantissa()`; owing to the previous change, the `rdxpp` parameter can no longer be null.


   

