### PR TITLE
Add L1 cache contention measurement tools

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -102,3 +102,15 @@ endfunction()
 
 add_benchmark_target(run-benchmark 10)
 add_benchmark_target(run-benchmark-fast 3)
+
+# Cache pressure measurement tool -- shares all dtoa implementations
+# but uses a different main() that measures L1 cache pollution.
+get_target_property(DTOA_SOURCES dtoa-benchmark SOURCES)
+list(REMOVE_ITEM DTOA_SOURCES src/benchmark.cc)
+add_executable(
+  cache-pressure
+  src/cache-pressure.cc
+  ${DTOA_SOURCES}
+)
+target_compile_features(cache-pressure PRIVATE cxx_std_20)
+target_include_directories(cache-pressure PRIVATE src src/fmt/include)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -114,3 +114,12 @@ add_executable(
 )
 target_compile_features(cache-pressure PRIVATE cxx_std_20)
 target_include_directories(cache-pressure PRIVATE src src/fmt/include)
+
+# L1 cache contention test -- measures dtoa degradation under L1 pressure.
+add_executable(
+  cache-contention
+  src/cache-contention.cc
+  ${DTOA_SOURCES}
+)
+target_compile_features(cache-contention PRIVATE cxx_std_20)
+target_include_directories(cache-contention PRIVATE src src/fmt/include)

--- a/src/cache-contention.cc
+++ b/src/cache-contention.cc
@@ -97,18 +97,7 @@ measure_contended(dtoa_fun dtoa, int competitor_lines, int rounds) {
 
   double total_ns =
       std::chrono::duration_cast<std::chrono::nanoseconds>(end - start).count();
-  // Subtract competitor overhead: measure it separately.
-  auto start2 = std::chrono::steady_clock::now();
-  for (int r = 0; r < rounds; r++) {
-    touch_competitor(competitor_lines);
-  }
-  auto end2 = std::chrono::steady_clock::now();
-  double competitor_ns =
-      std::chrono::duration_cast<std::chrono::nanoseconds>(end2 - start2)
-          .count();
-
-  double dtoa_ns = (total_ns - competitor_ns) / (rounds * CALLS_PER_ROUND);
-  return dtoa_ns;
+  return total_ns / (rounds * CALLS_PER_ROUND);
 }
 
 int main(int argc, char** argv) {

--- a/src/cache-contention.cc
+++ b/src/cache-contention.cc
@@ -34,8 +34,8 @@ register_method::register_method(const char* name, dtoa_fun dtoa) {
   methods.push_back(method{name, dtoa});
 }
 
-// Max competitor size: 28KB (leaves 4KB for stack/dtoa minimum).
-static constexpr int MAX_COMPETITOR_KB = 28;
+// Max competitor size: 64KB (past L1d to observe the cliff).
+static constexpr int MAX_COMPETITOR_KB = 64;
 static constexpr int MAX_COMPETITOR_LINES = MAX_COMPETITOR_KB * 1024 / 64;
 
 // Competitor working set, cache-line aligned.
@@ -125,8 +125,8 @@ int main(int argc, char** argv) {
   std::sort(methods.begin(), methods.end(),
             [](const method& a, const method& b) { return a.name < b.name; });
 
-  // Pressure levels: 0KB to 28KB in 4KB steps.
-  int pressures_kb[] = {0, 4, 8, 12, 16, 20, 24, 28};
+  // Pressure levels: 0KB up to 48KB (past L1d size to see the cliff).
+  int pressures_kb[] = {0, 4, 8, 12, 16, 20, 24, 28, 32, 36, 40, 48};
   int num_pressures = sizeof(pressures_kb) / sizeof(pressures_kb[0]);
 
   // Header.

--- a/src/cache-contention.cc
+++ b/src/cache-contention.cc
@@ -17,6 +17,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <unistd.h>
 
 #include <algorithm>
 #include <chrono>
@@ -34,8 +35,17 @@ register_method::register_method(const char* name, dtoa_fun dtoa) {
   methods.push_back(method{name, dtoa});
 }
 
-// Max competitor size: 64KB (past L1d to observe the cliff).
-static constexpr int MAX_COMPETITOR_KB = 64;
+// Detect L1 data cache size at runtime.
+static int get_l1d_size_kb() {
+#ifdef _SC_LEVEL1_DCACHE_SIZE
+  long size = sysconf(_SC_LEVEL1_DCACHE_SIZE);
+  if (size > 0) return static_cast<int>(size / 1024);
+#endif
+  return 32;  // Fallback: 32KB is the most common L1d size.
+}
+
+// Max competitor size: 2x L1d (past L1d to observe the cliff).
+static constexpr int MAX_COMPETITOR_KB = 128;
 static constexpr int MAX_COMPETITOR_LINES = MAX_COMPETITOR_KB * 1024 / 64;
 
 // Competitor working set, cache-line aligned.
@@ -52,22 +62,33 @@ touch_competitor(int num_lines) {
   }
 }
 
-// Test data: 64 random doubles.
-static constexpr int NUM_TEST_VALUES = 64;
+// Test data: uniform distribution across 1-17 significant digits.
+// 4 values per digit count = 68 values. This avoids the bias toward
+// 17-digit outputs that raw random bit patterns produce.
+static constexpr int MAX_DIGITS = 17;
+static constexpr int VALUES_PER_DIGIT = 4;
+static constexpr int NUM_TEST_VALUES = MAX_DIGITS * VALUES_PER_DIGIT;
 static double test_values[NUM_TEST_VALUES];
 
 static void init_test_values() {
   unsigned seed = 42;
-  for (int i = 0; i < NUM_TEST_VALUES; i++) {
-    uint64_t bits = 0;
-    seed = 214013 * seed + 2531011;
-    bits = uint64_t(seed) << 32;
-    seed = 214013 * seed + 2531011;
-    bits |= seed;
-    double d;
-    memcpy(&d, &bits, sizeof(d));
-    if (isnan(d) || isinf(d)) d = 1.23456789;
-    test_values[i] = d;
+  int idx = 0;
+  for (int digit = 1; digit <= MAX_DIGITS; digit++) {
+    for (int j = 0; j < VALUES_PER_DIGIT; j++) {
+      double d;
+      do {
+        uint64_t bits = 0;
+        seed = 214013 * seed + 2531011;
+        bits = uint64_t(seed) << 32;
+        seed = 214013 * seed + 2531011;
+        bits |= seed;
+        memcpy(&d, &bits, sizeof(d));
+      } while (isnan(d) || isinf(d));
+      // Reduce to the desired number of significant digits.
+      char buf[32];
+      snprintf(buf, sizeof(buf), "%.*g", digit, d);
+      test_values[idx++] = strtod(buf, nullptr);
+    }
   }
 }
 
@@ -114,15 +135,29 @@ int main(int argc, char** argv) {
   std::sort(methods.begin(), methods.end(),
             [](const method& a, const method& b) { return a.name < b.name; });
 
-  // Pressure levels: 0KB up to 48KB (past L1d size to see the cliff).
-  int pressures_kb[] = {0, 4, 8, 12, 16, 20, 24, 28, 32, 36, 40, 48};
-  int num_pressures = sizeof(pressures_kb) / sizeof(pressures_kb[0]);
+  // Compute column width from longest method name.
+  int name_width = 6;  // minimum: "------"
+  for (const auto& m : methods) {
+    int len = static_cast<int>(m.name.size());
+    if (len > name_width) name_width = len;
+  }
+  name_width += 2;  // padding
+
+  // Pressure levels: 4KB steps up to just past L1d size.
+  int l1d_kb = get_l1d_size_kb();
+  std::vector<int> pressures_kb = {0};
+  for (int kb = 4; kb <= l1d_kb + 4; kb += 4)
+    pressures_kb.push_back(kb);
+  int num_pressures = static_cast<int>(pressures_kb.size());
 
   // Header.
-  printf("L1 cache contention test (32KB L1d, 16 dtoa calls between competitor touches)\n");
-  printf("Competitor = simulated hot-path data (order book) competing for L1\n\n");
+  printf("L1 cache contention test (%dKB L1d, %d dtoa calls between competitor touches)\n",
+         l1d_kb, 16);
+  printf("Competitor = simulated hot-path data (order book) competing for L1\n");
+  printf("Test data = uniform mix of 1-%d significant digits (%d values)\n\n",
+         MAX_DIGITS, NUM_TEST_VALUES);
 
-  printf("%-14s", "Method");
+  printf("%-*s", name_width, "Method");
   for (int i = 0; i < num_pressures; i++) {
     char hdr[16];
     snprintf(hdr, sizeof(hdr), "%dKB", pressures_kb[i]);
@@ -130,7 +165,7 @@ int main(int argc, char** argv) {
   }
   printf("  %7s\n", "slowdown");
 
-  printf("%-14s", "------");
+  printf("%-*s", name_width, "------");
   for (int i = 0; i < num_pressures; i++) {
     printf(" %7s", "-------");
   }
@@ -141,7 +176,7 @@ int main(int argc, char** argv) {
       continue;
     if (filter && m.name != filter) continue;
 
-    printf("%-14s", m.name.c_str());
+    printf("%-*s", name_width, m.name.c_str());
     fflush(stdout);
 
     double baseline = 0;

--- a/src/cache-contention.cc
+++ b/src/cache-contention.cc
@@ -1,0 +1,186 @@
+// L1 cache contention test for dtoa implementations.
+//
+// Simulates a hot-path workload (order book, market data) that competes
+// for L1 data cache with the dtoa tables. Measures how dtoa throughput
+// degrades as the competing working set grows.
+//
+// Pin to an isolated core for clean results:
+//   taskset -c 18 ./cache-contention
+//
+// On a 32KB L1d, dragonbox (424B tables) should hold up much longer
+// than uscale (11.5KB tables) or ryu (10.9KB tables) as pressure grows.
+
+#include "benchmark.h"
+
+#include <math.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <algorithm>
+#include <chrono>
+#include <string>
+#include <vector>
+
+struct method {
+  std::string name;
+  dtoa_fun dtoa;
+};
+
+static std::vector<method> methods;
+
+register_method::register_method(const char* name, dtoa_fun dtoa) {
+  methods.push_back(method{name, dtoa});
+}
+
+// Max competitor size: 28KB (leaves 4KB for stack/dtoa minimum).
+static constexpr int MAX_COMPETITOR_KB = 28;
+static constexpr int MAX_COMPETITOR_LINES = MAX_COMPETITOR_KB * 1024 / 64;
+
+// Competitor working set, cache-line aligned.
+alignas(64) static volatile uint64_t
+    competitor[MAX_COMPETITOR_LINES * 8];  // 8 uint64 per line
+
+// Touch N cache lines of competitor data. Simulates order book access.
+static void __attribute__((noinline))
+touch_competitor(int num_lines) {
+  uint64_t sum = 0;
+  for (int i = 0; i < num_lines * 8; i += 8) {
+    sum += competitor[i];
+    competitor[i] = sum;  // Write too, so lines are dirty (realistic).
+  }
+}
+
+// Test data: 64 random doubles.
+static constexpr int NUM_TEST_VALUES = 64;
+static double test_values[NUM_TEST_VALUES];
+
+static void init_test_values() {
+  unsigned seed = 42;
+  for (int i = 0; i < NUM_TEST_VALUES; i++) {
+    uint64_t bits = 0;
+    seed = 214013 * seed + 2531011;
+    bits = uint64_t(seed) << 32;
+    seed = 214013 * seed + 2531011;
+    bits |= seed;
+    double d;
+    memcpy(&d, &bits, sizeof(d));
+    if (isnan(d) || isinf(d)) d = 1.23456789;
+    test_values[i] = d;
+  }
+}
+
+// Measure dtoa throughput while competing for L1 with a working set of
+// `competitor_lines` cache lines. Returns nanoseconds per dtoa call.
+static double __attribute__((noinline))
+measure_contended(dtoa_fun dtoa, int competitor_lines, int rounds) {
+  char buffer[256];
+  constexpr int CALLS_PER_ROUND = 16;  // Small batch between competitor touches.
+
+  // Warm up: bring competitor and dtoa tables into cache.
+  for (int w = 0; w < 3; w++) {
+    touch_competitor(competitor_lines);
+    for (int i = 0; i < CALLS_PER_ROUND; i++)
+      dtoa(test_values[i], buffer);
+  }
+
+  auto start = std::chrono::steady_clock::now();
+  for (int r = 0; r < rounds; r++) {
+    // Simulate: process market data (touch competitor), then format numbers.
+    touch_competitor(competitor_lines);
+    for (int i = 0; i < CALLS_PER_ROUND; i++) {
+      dtoa(test_values[i % NUM_TEST_VALUES], buffer);
+    }
+  }
+  auto end = std::chrono::steady_clock::now();
+
+  double total_ns =
+      std::chrono::duration_cast<std::chrono::nanoseconds>(end - start).count();
+  // Subtract competitor overhead: measure it separately.
+  auto start2 = std::chrono::steady_clock::now();
+  for (int r = 0; r < rounds; r++) {
+    touch_competitor(competitor_lines);
+  }
+  auto end2 = std::chrono::steady_clock::now();
+  double competitor_ns =
+      std::chrono::duration_cast<std::chrono::nanoseconds>(end2 - start2)
+          .count();
+
+  double dtoa_ns = (total_ns - competitor_ns) / (rounds * CALLS_PER_ROUND);
+  return dtoa_ns;
+}
+
+int main(int argc, char** argv) {
+  const char* filter = argc > 1 ? argv[1] : nullptr;
+  int rounds = argc > 2 ? atoi(argv[2]) : 100000;
+
+  init_test_values();
+
+  // Initialize competitor data.
+  for (int i = 0; i < MAX_COMPETITOR_LINES * 8; i++) {
+    competitor[i] = i * 0x9e3779b97f4a7c15ULL;
+  }
+
+  std::sort(methods.begin(), methods.end(),
+            [](const method& a, const method& b) { return a.name < b.name; });
+
+  // Pressure levels: 0KB to 28KB in 4KB steps.
+  int pressures_kb[] = {0, 4, 8, 12, 16, 20, 24, 28};
+  int num_pressures = sizeof(pressures_kb) / sizeof(pressures_kb[0]);
+
+  // Header.
+  printf("L1 cache contention test (32KB L1d, 16 dtoa calls between competitor touches)\n");
+  printf("Competitor = simulated hot-path data (order book) competing for L1\n\n");
+
+  printf("%-14s", "Method");
+  for (int i = 0; i < num_pressures; i++) {
+    char hdr[16];
+    snprintf(hdr, sizeof(hdr), "%dKB", pressures_kb[i]);
+    printf(" %7s", hdr);
+  }
+  printf("  %7s\n", "slowdown");
+
+  printf("%-14s", "------");
+  for (int i = 0; i < num_pressures; i++) {
+    printf(" %7s", "-------");
+  }
+  printf("  %7s\n", "-------");
+
+  for (const auto& m : methods) {
+    if (m.name == "null" || m.name == "ostringstream" || m.name == "sprintf")
+      continue;
+    if (filter && m.name != filter) continue;
+
+    printf("%-14s", m.name.c_str());
+    fflush(stdout);
+
+    double baseline = 0;
+    double worst = 0;
+
+    for (int i = 0; i < num_pressures; i++) {
+      int lines = pressures_kb[i] * 1024 / 64;
+      double ns = measure_contended(m.dtoa, lines, rounds);
+
+      // Take best of 3 runs for stability.
+      for (int retry = 0; retry < 2; retry++) {
+        double ns2 = measure_contended(m.dtoa, lines, rounds);
+        if (ns2 < ns) ns = ns2;
+      }
+
+      if (i == 0) baseline = ns;
+      if (ns > worst) worst = ns;
+
+      printf(" %6.1fns", ns);
+      fflush(stdout);
+    }
+
+    double slowdown = (worst / baseline - 1.0) * 100.0;
+    printf("  %5.0f%%\n", slowdown);
+  }
+
+  printf("\nSlowdown = worst case vs no-contention baseline\n");
+  printf("Lower slowdown = more cache-friendly implementation\n");
+
+  return 0;
+}

--- a/src/cache-pressure.cc
+++ b/src/cache-pressure.cc
@@ -1,0 +1,173 @@
+// Cache pressure test for dtoa implementations.
+// Measures how much L1 data cache pollution each dtoa implementation causes.
+//
+// Method: Pre-load a 16KB working set into L1d cache, call dtoa N times,
+// then measure how long it takes to re-read the working set. Longer reload
+// means more cache lines were evicted by the dtoa code+data.
+//
+// Usage: ./cache-pressure [method] [calls_per_round]
+// Run under: perf stat -e L1-dcache-loads,L1-dcache-load-misses ...
+
+#include "benchmark.h"
+
+#include <math.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <algorithm>
+#include <chrono>
+#include <string>
+#include <vector>
+
+struct method {
+  std::string name;
+  dtoa_fun dtoa;
+};
+
+static std::vector<method> methods;
+
+register_method::register_method(const char* name, dtoa_fun dtoa) {
+  methods.push_back(method{name, dtoa});
+}
+
+// Working set: 16KB = 256 cache lines on a 64-byte line size.
+// This fits comfortably in a 32KB L1d with room for stack/locals.
+static constexpr int NUM_CACHE_LINES = 256;
+static constexpr int INTS_PER_LINE = 8;  // 64 bytes / 8 bytes
+static constexpr int WORKING_SET_INTS = NUM_CACHE_LINES * INTS_PER_LINE;
+
+// Aligned to cache line boundary.
+alignas(64) static volatile uint64_t working_set[WORKING_SET_INTS];
+
+// Touch every cache line, return checksum.
+static uint64_t __attribute__((noinline, optimize("O1")))
+load_working_set() {
+  uint64_t sum = 0;
+  for (int i = 0; i < WORKING_SET_INTS; i += INTS_PER_LINE) {
+    sum += working_set[i];
+  }
+  return sum;
+}
+
+// Measure reload time in nanoseconds.
+static double measure_reload_ns() {
+  auto start = std::chrono::steady_clock::now();
+  volatile uint64_t sink = load_working_set();
+  (void)sink;
+  auto end = std::chrono::steady_clock::now();
+  return std::chrono::duration_cast<std::chrono::nanoseconds>(end - start)
+      .count();
+}
+
+// Test data: 64 random doubles (fits in one 512-byte region).
+static constexpr int NUM_TEST_VALUES = 64;
+static double test_values[NUM_TEST_VALUES];
+
+static void init_test_values() {
+  unsigned seed = 42;
+  for (int i = 0; i < NUM_TEST_VALUES; i++) {
+    uint64_t bits = 0;
+    seed = 214013 * seed + 2531011;
+    bits = uint64_t(seed) << 32;
+    seed = 214013 * seed + 2531011;
+    bits |= seed;
+    double d;
+    memcpy(&d, &bits, sizeof(d));
+    if (isnan(d) || isinf(d)) d = 1.23456789;
+    test_values[i] = d;
+  }
+}
+
+// Call dtoa exactly N times, cycling through test values.
+static void __attribute__((noinline))
+call_dtoa_n(dtoa_fun dtoa, int n) {
+  char buffer[256];
+  for (int i = 0; i < n; i++) {
+    dtoa(test_values[i % NUM_TEST_VALUES], buffer);
+  }
+}
+
+int main(int argc, char** argv) {
+  const char* filter = argc > 1 ? argv[1] : nullptr;
+  int calls_per_round = argc > 2 ? atoi(argv[2]) : 0;
+
+  init_test_values();
+
+  for (int i = 0; i < WORKING_SET_INTS; i++) {
+    working_set[i] = i * 0x9e3779b97f4a7c15ULL;
+  }
+
+  // Establish baseline: load + immediately reload.
+  double baseline_ns = 1e18;
+  for (int t = 0; t < 50; t++) {
+    load_working_set();
+    double ns = measure_reload_ns();
+    if (ns < baseline_ns) baseline_ns = ns;
+  }
+
+  printf("Working set: %d KB (%d cache lines), Baseline reload: %.0f ns\n",
+         (int)(NUM_CACHE_LINES * 64 / 1024), NUM_CACHE_LINES, baseline_ns);
+  printf("\n");
+
+  std::sort(methods.begin(), methods.end(),
+            [](const method& a, const method& b) { return a.name < b.name; });
+
+  // If a specific call count was given, just run that.
+  // Otherwise, sweep from 1 to 64 calls to show the eviction curve.
+  std::vector<int> call_counts;
+  if (calls_per_round > 0) {
+    call_counts = {calls_per_round};
+  } else {
+    call_counts = {1, 2, 4, 8, 16, 32, 64};
+  }
+
+  // Header.
+  printf("%-16s", "Method");
+  for (int n : call_counts) {
+    char hdr[32];
+    snprintf(hdr, sizeof(hdr), "%d call%s", n, n > 1 ? "s" : "");
+    printf(" %10s", hdr);
+  }
+  printf("\n");
+
+  printf("%-16s", "------");
+  for (size_t i = 0; i < call_counts.size(); i++) {
+    printf(" %10s", "----------");
+  }
+  printf("\n");
+
+  for (const auto& m : methods) {
+    if (m.name == "null" || m.name == "ostringstream" || m.name == "sprintf")
+      continue;
+    if (filter && m.name != filter) continue;
+
+    printf("%-16s", m.name.c_str());
+
+    for (int n : call_counts) {
+      // Take median of many trials for stability.
+      constexpr int NUM_TRIALS = 200;
+      double trials[NUM_TRIALS];
+
+      for (int t = 0; t < NUM_TRIALS; t++) {
+        load_working_set();           // Prime L1 with working set.
+        call_dtoa_n(m.dtoa, n);       // Pollute with dtoa.
+        trials[t] = measure_reload_ns();
+      }
+
+      std::sort(trials, trials + NUM_TRIALS);
+      double median_ns = trials[NUM_TRIALS / 2];
+      double penalty_ns = median_ns - baseline_ns;
+
+      printf(" %9.0fns", penalty_ns);
+    }
+    printf("\n");
+  }
+
+  printf("\nPenalty = median reload time after N dtoa calls minus baseline (%.0f ns)\n",
+         baseline_ns);
+  printf("Higher = more L1 cache eviction = worse for co-resident hot paths\n");
+
+  return 0;
+}


### PR DESCRIPTION
- Add a cache pressure measurement tool (src/cache-pressure.cc) that measures dtoa throughput under varying cache pressure levels
- Add an L1 cache contention test (src/cache-contention.cc) that measures how dtoa performance degrades as competing data fills L1 cache (up to 48KB to find the L1 cliff)
- Simplify contention measurement by removing separate competitor overhead subtraction