### PR TITLE
Fix three real bugs found by clang-tidy

### DIFF
--- a/src/benchmark.cc
+++ b/src/benchmark.cc
@@ -259,6 +259,10 @@ auto main(int argc, char** argv) -> int {
   std::string filename = fmt::format("results/{}_{}_{}{}.csv", MACHINE,
                                      os_name(), compiler_name(), commit_hash);
   FILE* f = fopen(filename.c_str(), "w");
+  if (!f) {
+    fmt::print("error: cannot open '{}' for writing\n", filename);
+    return 1;
+  }
   fmt::print(f, "Type,Function,Digit,Time(ns)\n");
   for (const method& m : methods) {
     fmt::print("Benchmarking randomdigit {:20} ... ", m.name);

--- a/src/cache-pressure.cc
+++ b/src/cache-pressure.cc
@@ -42,7 +42,14 @@ static constexpr int WORKING_SET_INTS = NUM_CACHE_LINES * INTS_PER_LINE;
 alignas(64) static volatile uint64_t working_set[WORKING_SET_INTS];
 
 // Touch every cache line, return checksum.
-static uint64_t __attribute__((noinline, optimize("O1")))
+// optimize("O1") prevents the compiler from vectorizing or merging the
+// volatile reads. Clang doesn't support optimize(), so use optnone there.
+#ifdef __clang__
+__attribute__((noinline, optnone))
+#else
+__attribute__((noinline, optimize("O1")))
+#endif
+static uint64_t
 load_working_set() {
   uint64_t sum = 0;
   for (int i = 0; i < WORKING_SET_INTS; i += INTS_PER_LINE) {

--- a/src/puff-test.cc
+++ b/src/puff-test.cc
@@ -4,8 +4,9 @@
 // Copyright (c) 2024, Victor Zverovich
 // License: https://github.com/fmtlib/fmt/blob/master/LICENSE
 
+#include <math.h>    // frexp, signbit
 #include <stdint.h>  // uint32_t
-#include <string.h>  // memcpy
+#include <string.h>  // memcpy, memmove
 
 #include <charconv>  // std::to_chars
 #include <limits>    // std::numeric_limits


### PR DESCRIPTION
## Summary
- **benchmark.cc**: null-check `fopen()` return before writing — segfaults if `results/` directory doesn't exist
- **cache-pressure.cc**: use `optnone` on Clang where `optimize("O1")` is silently ignored, which could let the compiler defeat the cache reload measurement
- **puff-test.cc**: add missing `<math.h>` include for `frexp`/`signbit` — compiles today only via transitive includes

## Test plan
- [x] Builds clean under GCC 13.3
- [x] Builds clean under Clang 18.1
- [x] Benchmark passes correctness verification under both compilers